### PR TITLE
Solved cross platform issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
 
     // Convert the (possibly) absolute path to a relative path expected by
     // `broccoli-sass-source-maps`
-    return filePath.replace(treeString + '/', '');
+    return path.relative(treeString, filePath);
   }
 
   return mergeTrees(trees);


### PR DESCRIPTION
The script wasn't able to extract relative file path on Windows. It is now fixed using Node's `path.relative()`.
